### PR TITLE
Feature - Improve bundling & add ES6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-env"],
+  "comments": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated source code to ES6 - made more readable
+- Rollup bundle config update
+- Updated dependencies, fixes nested array bug
+
 ## [1.0.1] - 2018-09-08
 
 ### Added

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,4 @@
+export default {
+  files: ['src/**/*.test.js'],
+  require: ['@babel/register'],
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env'],
-  comments: false,
-};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "files": [
     "lib/index.cjs.js",
     "lib/index.es.js",
-    "lib/index.umd.js"
+    "lib/index.iife.js"
   ],
   "browser": "lib/index.iife.js",
   "main": "lib/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lib/index.es.js",
     "lib/index.umd.js"
   ],
-  "browser": "lib/index.umd.js",
+  "browser": "lib/index.iife.js",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "keywords": [
@@ -63,6 +63,7 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "ava": "1.0.0-beta.8",
     "husky": "^1.0.0-rc.13",
     "lint-staged": "^7.2.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,28 +5,62 @@ import { terser } from 'rollup-plugin-terser';
 
 import pkg from './package.json';
 
+const commonJSConfig = {
+  namedExports: {
+    // left-hand side can be an absolute path, a path
+    // relative to the current directory, or the name
+    // of a module in node_modules
+    'node_modules/quick-lru/index.js': ['QuickLRU'],
+  },
+};
+
+const externals = ['camelcase', 'map-obj', 'quick-lru'];
+
+const globalDeps = {
+  camelcase: 'camelCase',
+  'map-obj': 'mapObj',
+  'quick-lru': 'QuickLRU',
+};
+
 export default [
   {
     input: 'src/index.js',
-    output: [
-      {
-        name: 'keysToCamelcase',
-        file: pkg.browser,
-        format: 'umd',
-      },
-      { file: pkg.main, format: 'cjs' },
-    ],
+    output: {
+      name: 'keysToCamelcase',
+      file: pkg.browser,
+      format: 'iife',
+    },
     plugins: [
       resolve(), // Allow rollup to 'see' dependencies
-      commonjs(), // Include dependency code in bundle
+      commonjs(commonJSConfig), // Include dependency code in bundle
       babel(), // Transpile using babel config
       terser(), // Minify / mangle using terser
     ],
   },
   {
+    external: externals,
     input: 'src/index.js',
-    output: { file: pkg.module, format: 'es' },
+    output: {
+      file: pkg.main,
+      format: 'cjs',
+      globals: globalDeps,
+    },
     plugins: [
+      resolve(), // Allow rollup to 'see' dependencies
+      babel(), // Transpile using babel config
+      terser(), // Minify / mangle using terser
+    ],
+  },
+  {
+    external: externals,
+    input: 'src/index.js',
+    output: {
+      file: pkg.module,
+      format: 'es',
+      globals: globalDeps,
+    },
+    plugins: [
+      resolve(), // Allow rollup to 'see' dependencies
       terser(), // Minify / mangle using terser
     ],
   },

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -47,7 +47,7 @@ test('nested arrays', t => {
   const originalObject = {
     q_w_e: [['a', 'b']],
   };
-  const updatedObject = camelCaseKeys(originalObject, { deep: true });
+  const updatedObject = keysToCamelcase(originalObject, { deep: true });
   const expectedObject = {
     qWE: [['a', 'b']],
   };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,23 +1,23 @@
 import test from 'ava';
-import camelCaseKeys from './index';
+import keysToCamelcase from './index';
 
 test('basic usage', t => {
   const originalObject = { 'foo-bar': true };
-  const updatedObject = camelCaseKeys(originalObject);
+  const updatedObject = keysToCamelcase(originalObject);
 
   t.true(!!updatedObject.fooBar);
 });
 
 test('exclude option - basic', t => {
   const originalObject = { '--': true };
-  const updatedObject = camelCaseKeys(originalObject, { exclude: ['--'] });
+  const updatedObject = keysToCamelcase(originalObject, { exclude: ['--'] });
 
   t.true(!!updatedObject['--']);
 });
 
 test('exclude option - regex', t => {
   const originalObject = { 'foo-bar': true, 'bar-foo': true };
-  const updatedObject = camelCaseKeys(originalObject, { exclude: [/^f/] });
+  const updatedObject = keysToCamelcase(originalObject, { exclude: [/^f/] });
   const expectedObject = { 'foo-bar': true, barFoo: true };
 
   t.deepEqual(updatedObject, expectedObject);
@@ -31,7 +31,7 @@ test('deep option', t => {
       arr: [{ three_four: true }],
     },
   };
-  const updatedObject = camelCaseKeys(originalObject, { deep: true });
+  const updatedObject = keysToCamelcase(originalObject, { deep: true });
   const expectedObject = {
     fooBar: true,
     obj: {
@@ -49,7 +49,7 @@ test('accepts an array of objects', t => {
     { bar_foo: false },
     { 'bar-foo': 'false' },
   ];
-  const updatedArray = camelCaseKeys(originalArray);
+  const updatedArray = keysToCamelcase(originalArray);
   const expectedArray = [
     { fooBar: true },
     { barFoo: false },

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,6 +535,18 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/register@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
+  dependencies:
+    core-js "^2.5.7"
+    find-cache-dir "^1.0.0"
+    home-or-tmp "^3.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pirates "^4.0.0"
+    source-map-support "^0.5.9"
+
 "@babel/template@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -1081,6 +1093,10 @@ common-path-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0"
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -1134,7 +1150,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^2.0.0:
+core-js@^2.0.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -1480,6 +1496,14 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -1692,6 +1716,10 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+home-or-tmp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -2492,6 +2520,10 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -2796,6 +2828,12 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pirates@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
+  dependencies:
+    node-modules-regexp "^1.0.0"
 
 pkg-conf@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR updates the rollup config to properly split the code into three distinct bundles. Also includes source-code updates to ES6, with transpilation pre-test using babel.

### Changes
- `@babel/register` added as a dependency
  - This allows ava to transpile the source code before operating on it
- `umd` build updated to `iife`
  - This reduces the support for some older browsers, but overall the build size/format is improved
- Three distinct configurations added to rollup
  - `iife` for browsers
  - `cjs` for node-based applications
  - `es` for build tools which are able to operate with es modules (webpack 4, rollup, etc.)